### PR TITLE
Add fields

### DIFF
--- a/app/bomber.py
+++ b/app/bomber.py
@@ -8,10 +8,14 @@ from app.game.bomber import BomberFactory
 @respond_to("start with (.*)")
 def start(message, who):
     message.reply("Yeah! Start bomber!!")
-
-    connect()
     BomberFactory.create(message.body["channel"], [
       "user1"
     ])
 
+    connect() # FIXME: this connect may be block a thread
+
+@respond_to("stop|quit|finish|end|bye")
+def end(message):
+    BomberFactory.remove(message.body["channel"])
+    message.reply("finished")
 

--- a/app/game/field.py
+++ b/app/game/field.py
@@ -1,0 +1,57 @@
+
+from enum import Enum
+
+class Object(Enum):
+    wall = 0
+    empty = 1
+    block = 2
+    bomb = 3
+
+class Item(Enum):
+    speed = 0
+    add_bomb = 1
+    fire = 2
+
+class Point:
+
+    def __init__(self, x, y):
+        self.x = x
+        self.y = y
+
+class Person:
+
+    def __init__(self, user, point=Point(0, 0)):
+        self.user = user
+        self.position = point
+
+
+class Field:
+    """
+        Access each field like _fields[x][y]
+        left-top is _fields[0][0]
+    """
+    def __init__(self, x_size, y_size, users):
+        self.x_size = x_size
+        self.y_size = y_size
+        self.bombs = [ [None]*y_size for x in range(x_size)]
+        map_ = FieldCreater.generate_map(x_size, y_size, len(users))
+        self.objects = map_["objects"]
+        self.items = map_["items"]
+        self.persons = [ Person(user, initial_pos)
+              for user, initial_pos in zip(users, map_["person_initial_positions"])
+            ]
+
+class FieldCreater:
+
+    @staticmethod
+    def generate_map(x_size, y_size, person_num):
+        # TODO: create a real map
+        return {
+            "objects":  [ [Object.empty]*y_size for x in range(x_size)],
+            "items": [ [None]*y_size for x in range(x_size)],
+            "person_initial_positions": [
+                Point(0, 0),
+                Point(x_size-1, y_size-1),
+            ],
+        }
+

--- a/app/game/field_outputter.py
+++ b/app/game/field_outputter.py
@@ -10,8 +10,21 @@ class FieldOutputter:
         if new_message or channel not in cls.recent_field_ts:
             res = slacker.chat.post_message(channel, field_text)
             cls.recent_field_ts[channel] = res.body["ts"]
+            cls.add_controller(channel, res.body["ts"])
         else:
             ts = cls.recent_field_ts[channel]
             import random
             slacker.chat.update(channel, ts, field_text+"(edited)"+str(random.random())) # TODO: remove this string
+
+    @classmethod
+    def add_controller(cls, channel, ts):
+        for reaction in  [
+            "arrow_left",
+            "arrow_up",
+            "arrow_down",
+            "arrow_right",
+            "a",
+        ]:
+            # It should run in parallel? Think and Implement if needed.
+            slacker.reactions.add(reaction, channel=channel, timestamp=ts)
 

--- a/app/game/field_outputter.py
+++ b/app/game/field_outputter.py
@@ -1,0 +1,16 @@
+
+from app.slack import slacker
+
+class FieldOutputter:
+    recent_field_ts = {}
+
+    @classmethod
+    def post_field(cls, channel, field, new_message=False):
+        field_text = "TODO: create this by field"
+        if new_message or channel not in cls.recent_field_ts:
+            res = slacker.chat.post_message(channel, field_text)
+            cls.recent_field_ts[channel] = res.body["ts"]
+        else:
+            ts = cls.recent_field_ts[channel]
+            slacker.chat.update(channel, ts, field_text+"(edited)") # TODO: remove this string
+

--- a/app/game/field_outputter.py
+++ b/app/game/field_outputter.py
@@ -12,5 +12,6 @@ class FieldOutputter:
             cls.recent_field_ts[channel] = res.body["ts"]
         else:
             ts = cls.recent_field_ts[channel]
-            slacker.chat.update(channel, ts, field_text+"(edited)") # TODO: remove this string
+            import random
+            slacker.chat.update(channel, ts, field_text+"(edited)"+str(random.random())) # TODO: remove this string
 

--- a/test/game/bomber_test.py
+++ b/test/game/bomber_test.py
@@ -1,12 +1,20 @@
 
 import unittest
+from unittest.mock import patch
 
 from app.game.bomber import BomberFactory, Bomber
 
-class InputTest(unittest.TestCase):
+class BomberTest(unittest.TestCase):
 
     def setUp(self):
-        pass
+        self.patcher = patch("app.game.bomber.slacker")
+        self.patcher.start()
+        self.patcher2 = patch("app.game.bomber.Bomber.start")
+        self.patcher2.start()
+
+    def tearDown(self):
+        self.patcher.stop()
+        self.patcher2.stop()
 
     def test_BomberFactory_should_create_bomber_instance(self):
         bomber = BomberFactory.create("channel", [])

--- a/test/game/field_outputter_test.py
+++ b/test/game/field_outputter_test.py
@@ -16,6 +16,7 @@ class FieldOutputterTest(unittest.TestCase):
         mock.body = {"ts": "tsvalue"}
         mocked_slacker.chat.post_message.return_value = mock
         mocked_slacker.chat.update.return_value = None
+        mocked_slacker.reactions.add.return_value = None
         FieldOutputter.post_field("channel", None)
         self.assertTrue(mocked_slacker.chat.post_message.called)
         self.assertFalse(mocked_slacker.chat.update.called)
@@ -27,6 +28,7 @@ class FieldOutputterTest(unittest.TestCase):
         mock.body = {"ts": "tsvalue"}
         mocked_slacker.chat.post_message.return_value = mock
         mocked_slacker.chat.update.return_value = None
+        mocked_slacker.reactions.add.return_value = None
         FieldOutputter.post_field("channel", None)
         self.assertTrue(mocked_slacker.chat.post_message.called)
         self.assertFalse(mocked_slacker.chat.update.called)
@@ -40,6 +42,7 @@ class FieldOutputterTest(unittest.TestCase):
         mock.body = {"ts": "tsvalue"}
         mocked_slacker.chat.post_message.return_value = mock
         mocked_slacker.chat.update.return_value = None
+        mocked_slacker.reactions.add.return_value = None
         FieldOutputter.post_field("channel", None)
         self.assertTrue(mocked_slacker.chat.post_message.called)
         self.assertFalse(mocked_slacker.chat.update.called)

--- a/test/game/field_outputter_test.py
+++ b/test/game/field_outputter_test.py
@@ -1,0 +1,50 @@
+
+import unittest
+from unittest.mock import Mock, patch
+
+from app.game.field_outputter import FieldOutputter
+
+class FieldOutputterTest(unittest.TestCase):
+
+    def setUp(self):
+        pass
+
+    @patch("app.game.field_outputter.slacker")
+    def test_outputter_send_new_message(self, mocked_slacker):
+        FieldOutputter.recent_field_ts = {}
+        mock = Mock()
+        mock.body = {"ts": "tsvalue"}
+        mocked_slacker.chat.post_message.return_value = mock
+        mocked_slacker.chat.update.return_value = None
+        FieldOutputter.post_field("channel", None)
+        self.assertTrue(mocked_slacker.chat.post_message.called)
+        self.assertFalse(mocked_slacker.chat.update.called)
+
+    @patch("app.game.field_outputter.slacker")
+    def test_Field_should_edit_in_second_post(self, mocked_slacker):
+        FieldOutputter.recent_field_ts = {}
+        mock = Mock()
+        mock.body = {"ts": "tsvalue"}
+        mocked_slacker.chat.post_message.return_value = mock
+        mocked_slacker.chat.update.return_value = None
+        FieldOutputter.post_field("channel", None)
+        self.assertTrue(mocked_slacker.chat.post_message.called)
+        self.assertFalse(mocked_slacker.chat.update.called)
+        FieldOutputter.post_field("channel", None)
+        self.assertTrue(mocked_slacker.chat.update.called)
+
+    @patch("app.game.field_outputter.slacker")
+    def test_Field_should_post_to_other_channel(self, mocked_slacker):
+        FieldOutputter.recent_field_ts = {}
+        mock = Mock()
+        mock.body = {"ts": "tsvalue"}
+        mocked_slacker.chat.post_message.return_value = mock
+        mocked_slacker.chat.update.return_value = None
+        FieldOutputter.post_field("channel", None)
+        self.assertTrue(mocked_slacker.chat.post_message.called)
+        self.assertFalse(mocked_slacker.chat.update.called)
+        mocked_slacker.chat.post_message.called = False
+        FieldOutputter.post_field("channel2", None)
+        self.assertTrue(mocked_slacker.chat.post_message.called)
+        self.assertFalse(mocked_slacker.chat.update.called)
+

--- a/test/game/field_test.py
+++ b/test/game/field_test.py
@@ -1,0 +1,19 @@
+
+import unittest
+
+from app.game.field import Field
+
+class FieldTest(unittest.TestCase):
+
+    def setUp(self):
+        pass
+
+    def test_Field_should_create(self):
+        field = Field(8, 10, ["user1", "user2"])
+        field.objects[0][0]
+        field.objects[7][9]
+        with self.assertRaises(IndexError) as error:
+            field.objects[8][9]
+        with self.assertRaises(IndexError) as error:
+            field.objects[7][10]
+


### PR DESCRIPTION
Implement a function which output fields and field manager class.

Field class has a function of field management which has objects like blocks, grasses, bombs, users... The objects express an bomber-man field.

FieldOutputter class has a static method for posting to slack.
The method received two required variables `field` and `channel`.
`field` is instance of Field class. Calling this method, the `field` posts (or edits) to the channel.
If the class have not post to the channel or new_message flag is True, the class attempt to post a new chat. Otherwise the class edits the newest chat.


I found `connect` function is not work I though. I have not checked it, but `run_forever` method may blocks thread. In this time, it works, so I write a todo annotation.